### PR TITLE
Add missing keys from answers into answeres_test.py to clear test failure

### DIFF
--- a/assignment/a0/a0.ipynb
+++ b/assignment/a0/a0.ipynb
@@ -1,235 +1,382 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Assignment 0\n",
-        "\n",
-        "This notebook will help verify that you're all set up with the Python packages we'll be using this semester.\n",
-        "\n",
-        "**Your task:** just run the cells below, and verify that the output is as expected. If anything looks wrong, weird, or crashes, update your Python installation or contact the course staff. We don't want library issues to get in the way of the real coursework!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [],
-      "source": [
-        "# Version checks\n",
-        "import importlib\n",
-        "def version_greater_equal(v1, v2):\n",
-        "    for x, y in zip(v1.split('.'), v2.split('.')):\n",
-        "        if int(x) != int(y):\n",
-        "            return int(x) > int(y)\n",
-        "    return True\n",
-        "    \n",
-        "assert version_greater_equal('1.2.3', '0.1.1')\n",
-        "assert version_greater_equal('1.2.3', '0.5.1')\n",
-        "assert version_greater_equal('1.2.3', '1.2.3')\n",
-        "assert version_greater_equal('0.22.0', '0.20.3')\n",
-        "assert not version_greater_equal('1.1.1', '1.2.3')\n",
-        "assert not version_greater_equal('0.5.1', '1.2.3')\n",
-        "assert not version_greater_equal('0.20.3', '0.22.0')\n",
-        "\n",
-        "def version_check(libname, min_version):\n",
-        "    m = importlib.import_module(libname)\n",
-        "    print (\"%s version %s is \" % (libname, m.__version__))\n",
-        "    print (\"OK\"\n",
-        "           if version_greater_equal(m.__version__, min_version) \n",
-        "           else \"out-of-date. Please upgrade!\")\n",
-        "    \n",
-        "version_check(\"numpy\", \"1.23.5\")\n",
-        "version_check(\"matplotlib\", \"3.7.0\")\n",
-        "version_check(\"pandas\", \"1.5.3\")\n",
-        "version_check(\"nltk\", \"3.7\")\n",
-        "version_check(\"keras\", \"2.11.0\")\n",
-        "version_check(\"tensorflow\", \"2.11.0\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## TensorFlow\n",
-        "\n",
-        "We'll be using [TensorFlow](tensorflow.org) to build deep learning models this semester. TensorFlow is a whole programming system in itself, based around the idea of a computation graph and deferred execution. We'll be talking a lot more about it in Assignment 1, but for now you should just test that it loads on your system.\n",
-        "\n",
-        "Run the cell below; you should see:\n",
-        "```\n",
-        "Hello, TensorFlow!\n",
-        "42\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import tensorflow as tf\n",
-        "\n",
-        "hello = tf.constant(\"Hello, TensorFlow!\")\n",
-        "tf.print(hello)\n",
-        "\n",
-        "a = tf.constant(10)\n",
-        "b = tf.constant(32)\n",
-        "tf.print((a+b))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## NLTK\n",
-        "\n",
-        "[NLTK](http://www.nltk.org/) is a large compilation of Python NLP packages. It includes implementations of a number of classic NLP models, as well as utilities for working with linguistic data structures, preprocessing text, and managing corpora.\n",
-        "\n",
-        "NLTK is included with Anaconda, but the corpora need to be downloaded separately. Be warned that this will take up around 3.2 GB of disk space if you download everything! If this is too much, you can download individual corpora as you need them through the same interface.\n",
-        "\n",
-        "Type the following into a Python shell on the command line. It'll open a pop-up UI with the downloader:\n",
-        "\n",
-        "```\n",
-        "import nltk\n",
-        "nltk.download()\n",
-        "```\n",
-        "\n",
-        "Alternatively, you can download individual corpora by name. The cell below will download the famous [Reuters-21578 benchmark corpus](https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.html):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import nltk\n",
-        "assert(nltk.download('punkt'))\n",
-        "assert(nltk.download('reuters'))  # should return True if successful, or already installed"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Now we can look at a few sentences. Expect to see:\n",
-        "```\n",
-        "ASIAN EXPORTERS FEAR DAMAGE FROM U . S .- JAPAN RIFT Mounting trade friction between the U . S . And Japan has raised fears among many of Asia ' s exporting nations that the row could inflict far - reaching economic damage , businessmen and officials said .\n",
-        "\n",
-        "They told Reuter correspondents in Asian capitals a U . S . Move against Japan might boost protectionist sentiment in the U . S . And lead to curbs on American imports of their products .\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from nltk.corpus import reuters\n",
-        "# Look at the first two sentences\n",
-        "for s in reuters.sents()[:2]:\n",
-        "    print(\" \".join(s))\n",
-        "    print(\"\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "NLTK also includes a sample of the [Penn treebank](https://www.cis.upenn.edu/~treebank/), which we'll be using later in the course for parsing and part-of-speech tagging. Here's a sample of sentences, and an example tree. Expect to see:\n",
-        "```\n",
-        "The top money funds are currently yielding well over 9 % .\n",
-        "\n",
-        "(S\n",
-        "  (NP-SBJ (DT The) (JJ top) (NN money) (NNS funds))\n",
-        "  (VP\n",
-        "    (VBP are)\n",
-        "    (ADVP-TMP (RB currently))\n",
-        "    (VP (VBG yielding) (NP (QP (RB well) (IN over) (CD 9)) (NN %))))\n",
-        "  (. .))\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "assert(nltk.download(\"treebank\"))  # should return True if successful, or already installed\n",
-        "print(\"\")\n",
-        "from nltk.corpus import treebank\n",
-        "# Look at the parse of a sentence.\n",
-        "# Don't worry about what this means yet!\n",
-        "idx = 45\n",
-        "print(\" \".join(treebank.sents()[idx]))\n",
-        "print(\"\")\n",
-        "print(treebank.parsed_sents()[idx])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can also look at the [Europarl corpus](http://www.statmt.org/europarl/), which consists of *parallel* text - a sentence and its translations to multiple languages. You should see:\n",
-        "```\n",
-        "ENGLISH: Resumption of the session I declare resumed the session of the European Parliament adjourned on Friday 17 December 1999 , and I would like once again to wish you a happy new year in the hope that you enjoyed a pleasant festive period .\n",
-        "```\n",
-        "and its translation into French and Spanish."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "assert(nltk.download(\"europarl_raw\"))  # should return True if successful, or already installed\n",
-        "print(\"\")\n",
-        "from nltk.corpus import europarl_raw\n",
-        "\n",
-        "idx = 0\n",
-        "\n",
-        "print(\"ENGLISH: \" + \" \".join(europarl_raw.english.sents()[idx]))\n",
-        "print(\"\")\n",
-        "print(\"FRENCH: \" + \" \".join(europarl_raw.french.sents()[idx]))\n",
-        "print(\"\")\n",
-        "print(\"SPANISH: \" + \" \".join(europarl_raw.spanish.sents()[idx]))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "anaconda-cloud": {},
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.5"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Assignment 0\n",
+    "\n",
+    "This notebook will help verify that you're all set up with the Python packages we'll be using this semester.\n",
+    "\n",
+    "**Your task:** just run the cells below, and verify that the output is as expected. If anything looks wrong, weird, or crashes, update your Python installation or contact the course staff. We don't want library issues to get in the way of the real coursework!"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 1
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numpy version 1.23.5 is \n",
+      "OK\n",
+      "matplotlib version 3.7.1 is \n",
+      "OK\n",
+      "pandas version 2.0.1 is \n",
+      "OK\n",
+      "nltk version 3.8.1 is \n",
+      "OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-05-08 16:25:23.340097: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "keras version 2.12.0 is \n",
+      "OK\n",
+      "tensorflow version 2.12.0 is \n",
+      "OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Version checks\n",
+    "import importlib\n",
+    "def version_greater_equal(v1, v2):\n",
+    "    for x, y in zip(v1.split('.'), v2.split('.')):\n",
+    "        if int(x) != int(y):\n",
+    "            return int(x) > int(y)\n",
+    "    return True\n",
+    "    \n",
+    "assert version_greater_equal('1.2.3', '0.1.1')\n",
+    "assert version_greater_equal('1.2.3', '0.5.1')\n",
+    "assert version_greater_equal('1.2.3', '1.2.3')\n",
+    "assert version_greater_equal('0.22.0', '0.20.3')\n",
+    "assert not version_greater_equal('1.1.1', '1.2.3')\n",
+    "assert not version_greater_equal('0.5.1', '1.2.3')\n",
+    "assert not version_greater_equal('0.20.3', '0.22.0')\n",
+    "\n",
+    "def version_check(libname, min_version):\n",
+    "    m = importlib.import_module(libname)\n",
+    "    print (\"%s version %s is \" % (libname, m.__version__))\n",
+    "    print (\"OK\"\n",
+    "           if version_greater_equal(m.__version__, min_version) \n",
+    "           else \"out-of-date. Please upgrade!\")\n",
+    "    \n",
+    "version_check(\"numpy\", \"1.23.5\")\n",
+    "version_check(\"matplotlib\", \"3.7.0\")\n",
+    "version_check(\"pandas\", \"1.5.3\")\n",
+    "version_check(\"nltk\", \"3.7\")\n",
+    "version_check(\"keras\", \"2.11.0\")\n",
+    "version_check(\"tensorflow\", \"2.11.0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TensorFlow\n",
+    "\n",
+    "We'll be using [TensorFlow](tensorflow.org) to build deep learning models this semester. TensorFlow is a whole programming system in itself, based around the idea of a computation graph and deferred execution. We'll be talking a lot more about it in Assignment 1, but for now you should just test that it loads on your system.\n",
+    "\n",
+    "Run the cell below; you should see:\n",
+    "```\n",
+    "Hello, TensorFlow!\n",
+    "42\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, TensorFlow!\n",
+      "42\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-05-08 16:25:24.793483: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:24.800589: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:24.800936: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:24.803469: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:24.803896: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:24.804213: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:25.710899: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:25.711222: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:25.711236: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1722] Could not identify NUMA node of platform GPU id 0, defaulting to 0.  Your kernel may not have been built with NUMA support.\n",
+      "2023-05-08 16:25:25.711510: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:982] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node\n",
+      "Your kernel may have been built without NUMA support.\n",
+      "2023-05-08 16:25:25.711598: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1635] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 8859 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 2080 Ti, pci bus id: 0000:01:00.0, compute capability: 7.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "hello = tf.constant(\"Hello, TensorFlow!\")\n",
+    "tf.print(hello)\n",
+    "\n",
+    "a = tf.constant(10)\n",
+    "b = tf.constant(32)\n",
+    "tf.print((a+b))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## NLTK\n",
+    "\n",
+    "[NLTK](http://www.nltk.org/) is a large compilation of Python NLP packages. It includes implementations of a number of classic NLP models, as well as utilities for working with linguistic data structures, preprocessing text, and managing corpora.\n",
+    "\n",
+    "NLTK is included with Anaconda, but the corpora need to be downloaded separately. Be warned that this will take up around 3.2 GB of disk space if you download everything! If this is too much, you can download individual corpora as you need them through the same interface.\n",
+    "\n",
+    "Type the following into a Python shell on the command line. It'll open a pop-up UI with the downloader:\n",
+    "\n",
+    "```\n",
+    "import nltk\n",
+    "nltk.download()\n",
+    "```\n",
+    "\n",
+    "Alternatively, you can download individual corpora by name. The cell below will download the famous [Reuters-21578 benchmark corpus](https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.html):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package punkt to /root/nltk_data...\n",
+      "[nltk_data]   Unzipping tokenizers/punkt.zip.\n",
+      "[nltk_data] Downloading package reuters to /root/nltk_data...\n"
+     ]
+    }
+   ],
+   "source": [
+    "import nltk\n",
+    "assert(nltk.download('punkt'))\n",
+    "assert(nltk.download('reuters'))  # should return True if successful, or already installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can look at a few sentences. Expect to see:\n",
+    "```\n",
+    "ASIAN EXPORTERS FEAR DAMAGE FROM U . S .- JAPAN RIFT Mounting trade friction between the U . S . And Japan has raised fears among many of Asia ' s exporting nations that the row could inflict far - reaching economic damage , businessmen and officials said .\n",
+    "\n",
+    "They told Reuter correspondents in Asian capitals a U . S . Move against Japan might boost protectionist sentiment in the U . S . And lead to curbs on American imports of their products .\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ASIAN EXPORTERS FEAR DAMAGE FROM U . S .- JAPAN RIFT Mounting trade friction between the U . S . And Japan has raised fears among many of Asia ' s exporting nations that the row could inflict far - reaching economic damage , businessmen and officials said .\n",
+      "\n",
+      "They told Reuter correspondents in Asian capitals a U . S . Move against Japan might boost protectionist sentiment in the U . S . And lead to curbs on American imports of their products .\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from nltk.corpus import reuters\n",
+    "# Look at the first two sentences\n",
+    "for s in reuters.sents()[:2]:\n",
+    "    print(\" \".join(s))\n",
+    "    print(\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NLTK also includes a sample of the [Penn treebank](https://www.cis.upenn.edu/~treebank/), which we'll be using later in the course for parsing and part-of-speech tagging. Here's a sample of sentences, and an example tree. Expect to see:\n",
+    "```\n",
+    "The top money funds are currently yielding well over 9 % .\n",
+    "\n",
+    "(S\n",
+    "  (NP-SBJ (DT The) (JJ top) (NN money) (NNS funds))\n",
+    "  (VP\n",
+    "    (VBP are)\n",
+    "    (ADVP-TMP (RB currently))\n",
+    "    (VP (VBG yielding) (NP (QP (RB well) (IN over) (CD 9)) (NN %))))\n",
+    "  (. .))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package treebank to /root/nltk_data...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "The top money funds are currently yielding well over 9 % .\n",
+      "\n",
+      "(S\n",
+      "  (NP-SBJ (DT The) (JJ top) (NN money) (NNS funds))\n",
+      "  (VP\n",
+      "    (VBP are)\n",
+      "    (ADVP-TMP (RB currently))\n",
+      "    (VP (VBG yielding) (NP (QP (RB well) (IN over) (CD 9)) (NN %))))\n",
+      "  (. .))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data]   Unzipping corpora/treebank.zip.\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert(nltk.download(\"treebank\"))  # should return True if successful, or already installed\n",
+    "print(\"\")\n",
+    "from nltk.corpus import treebank\n",
+    "# Look at the parse of a sentence.\n",
+    "# Don't worry about what this means yet!\n",
+    "idx = 45\n",
+    "print(\" \".join(treebank.sents()[idx]))\n",
+    "print(\"\")\n",
+    "print(treebank.parsed_sents()[idx])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also look at the [Europarl corpus](http://www.statmt.org/europarl/), which consists of *parallel* text - a sentence and its translations to multiple languages. You should see:\n",
+    "```\n",
+    "ENGLISH: Resumption of the session I declare resumed the session of the European Parliament adjourned on Friday 17 December 1999 , and I would like once again to wish you a happy new year in the hope that you enjoyed a pleasant festive period .\n",
+    "```\n",
+    "and its translation into French and Spanish."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package europarl_raw to /root/nltk_data...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "ENGLISH: Resumption of the session I declare resumed the session of the European Parliament adjourned on Friday 17 December 1999 , and I would like once again to wish you a happy new year in the hope that you enjoyed a pleasant festive period .\n",
+      "\n",
+      "FRENCH: Reprise de la session Je déclare reprise la session du Parlement européen qui avait été interrompue le vendredi 17 décembre dernier et je vous renouvelle tous mes vux en espérant que vous avez passé de bonnes vacances .\n",
+      "\n",
+      "SPANISH: Reanudación del período de sesiones Declaro reanudado el período de sesiones del Parlamento Europeo , interrumpido el viernes 17 de diciembre pasado , y reitero a Sus Señorías mi deseo de que hayan tenido unas buenas vacaciones .\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data]   Unzipping corpora/europarl_raw.zip.\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert(nltk.download(\"europarl_raw\"))  # should return True if successful, or already installed\n",
+    "print(\"\")\n",
+    "from nltk.corpus import europarl_raw\n",
+    "\n",
+    "idx = 0\n",
+    "\n",
+    "print(\"ENGLISH: \" + \" \".join(europarl_raw.english.sents()[idx]))\n",
+    "print(\"\")\n",
+    "print(\"FRENCH: \" + \" \".join(europarl_raw.french.sents()[idx]))\n",
+    "print(\"\")\n",
+    "print(\"SPANISH: \" + \" \".join(europarl_raw.spanish.sents()[idx]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/assignment/a0/answers
+++ b/assignment/a0/answers
@@ -8,13 +8,13 @@
 #      course policy, while still being confident everyone has read the syllabus.
 
 # Replace the next two lines with your name.
-last_name: Lastname
-first_name: FirstName
+last_name: Brown
+first_name: Ed
 
 # Replace the next line with your Berkeley email address.
 # We use it to give you access to the grading sheet.  It *must* be @berkeley.edu.
 # See the assignment instructions on how to get one if you don't have one already!
-email: placeholder@berkeley.edu
+email: edbrown@berkeley.edu
 
 ## Read the following thoroughly:
 #  - syllabus/README.md
@@ -26,10 +26,8 @@ email: placeholder@berkeley.edu
 
 main_components:
   - Term project
-  - Midterm examination
   - Assignments
   - Participation
-  - Final examination
 
 # 2.  What are the three graded components of the project?
 # (Delete the incorrect answers.)
@@ -37,22 +35,20 @@ main_components:
 project_components:
   - Proposal
   - Presentation
-  - Office hour proposal discussions
-  - Milestone
   - Final report
 
 # 3. How many late days can you use over the semester?
 # (Replace the 0 with the right answer.)
-late_days: 0
+late_days: 5
 
 # 4. How many late days can you use on a single assignment?
 # (Replace the 0 with the right answer.)
-late_days_per: 0
+late_days_per: 2
 
 # 5. If you run out of late days, and hand it in 12 hours after the deadline,
 #    how much is your grade reduced on that assignment?
 # (Replace the 0 with the right answer.)
-late_penalty: 0%age points
+late_penalty: 10%age points
 
 # 7. 48 hours after the deadline, what is the maximum assignment grade?
 # (Replace the 0 with the right answer.)
@@ -62,36 +58,25 @@ past_hard_deadline_grade: 0
 # (Delete the incorrect answers.)
 general_questions:
   - Public post on Ed Discussion
-  - Private post on Ed Discussion addressed to all instructors so they can load balance
-  - Private post on Ed Discussion addressed to your live session instructor
-  - Instructor email list
-  - Your live session instructor's berkeley email address
 
 # 9. Which of the following are appropriate places to ask questions that cannot be made
 #    public (e.g. ones that contain assignment solutions?)
 # (Delete the incorrect answers.)
 private_questions:
-  - Public post on Ed Discussion
   - Private post on Ed Discussion addressed to all instructors so they can load balance
   - Private post on Ed Discussion addressed to your live session instructor
-  - Instructor email list
-  - Your live session instructor's berkeley email address
 
 # 10. If you need something beyond the late day policy, what do you do?
 # (Delete the incorrect answers.)
 beyond_late_days:
   - Email the instructor mailing list, and cc student support as early as possible,
     even if you aren't completely sure you'll need anything.
-  - Ask on Ed Discussion
-  - Wait until the most dire consequences are upon you before mentioning anything
 
 # 11. Where do you find out which async to watch each week?
 # (Delete the incorrect answers.)
 async_source:
   - The "Async to watch" column in the syllabus
-  - Watch "Unit x" while preparing for "Week x"'s live session.
-  - Ask on Ed Discussion
-  - I don't watch async.
+
 
 # 12. This course isn't known as a super easy class and I should be cautious about taking it
 #     in conjunction with:
@@ -104,15 +89,14 @@ competing_worries:
 # 13. The grade distribution in this course has historically been
 # approximately (despite most students working really hard!):
 # (Replace the 0s with the correct values. Hint: even distribution)
-grade_A: 0%
-grade_A-: 0%
-grade_B+: 0%
-grade_B: 0%
+grade_A: 25%
+grade_A-: 25%
+grade_B+: 25%
+grade_B: 25%
 
 # 14. I would rather:
 # (Keep the one you agree with most.. no right answer here, this is us experimenting with the course and appreciate your feedback!)
 logistics_approach:
-  - Spend the first live session going over this in detail
   - Read it on my own, do this quiz, and spend live session time on course material, knowing I can ask questions on Ed Discussion and in Live Session as necessary
 
 # 15. "But I really wanted to say something more nuanced on the previous question!"

--- a/assignment/a0/answers_test.py
+++ b/assignment/a0/answers_test.py
@@ -10,6 +10,7 @@ class AnswersTest(unittest.TestCase):
             'competing_worries',
             'email',
             'first_name',
+            'general_questions',
             'grade_A-',
             'grade_A',
             'grade_B',
@@ -21,7 +22,8 @@ class AnswersTest(unittest.TestCase):
             'logistics_approach',
             'main_components',
             'past_hard_deadline_grade',
-            'project_components']
+            'project_components',
+            'private_questions']
 
     ANSWER_HASHES = {
         'async_source': 'af14f', 'beyond_late_days': '712b8', 'competing_worries': '306a5', 'grade_A': '7a80b', 'grade_A-': 'b5fa3', 'grade_B': 'b9885', 'grade_B+': 'af75c', 'late_days': '9386a', 'late_days_per': '5ddcb', 'late_penalty': '15fde', 'main_components': '87d41', 'past_hard_deadline_grade': 'e4012', 'project_components': '9f392'}


### PR DESCRIPTION
The answers file distributed with 2023-summer-main has two more "keys" than the answers_test.py file. This causes a test failure for test_keys. Fix: Add in private_questions and general_questions to REQUIRED_ANSWERS list. 