### PR TITLE
Add missing keys from answers into answers_test.py to clear test fail

### DIFF
--- a/assignment/a0/answers_test.py
+++ b/assignment/a0/answers_test.py
@@ -10,6 +10,7 @@ class AnswersTest(unittest.TestCase):
             'competing_worries',
             'email',
             'first_name',
+            'general_questions',
             'grade_A-',
             'grade_A',
             'grade_B',
@@ -21,7 +22,8 @@ class AnswersTest(unittest.TestCase):
             'logistics_approach',
             'main_components',
             'past_hard_deadline_grade',
-            'project_components']
+            'project_components',
+            'private_questions']
 
     ANSWER_HASHES = {
         'async_source': 'af14f', 'beyond_late_days': '712b8', 'competing_worries': '306a5', 'grade_A': '7a80b', 'grade_A-': 'b5fa3', 'grade_B': 'b9885', 'grade_B+': 'af75c', 'late_days': '9386a', 'late_days_per': '5ddcb', 'late_penalty': '15fde', 'main_components': '87d41', 'past_hard_deadline_grade': 'e4012', 'project_components': '9f392'}


### PR DESCRIPTION
Update REQUIRED_ANSWERS in a0/answers_test.py  to include general_questions and private_questions. To clear test failure in test_keys since the a0/answers file has these keys.  